### PR TITLE
Semi-Important Fix

### DIFF
--- a/Hooks/Client/Client.cpp
+++ b/Hooks/Client/Client.cpp
@@ -29,11 +29,6 @@ void __fastcall BaseClient::LevelShutdown::Detour(void* ecx, void* edx)
 	Table.Original<FN>(Index)(ecx, edx);
 }
 
-void __fastcall BaseClient::CreateMove::Detour(void* ecx, void* edx, int sequence_number, float input_sample_frametime, bool active)
-{
-	Table.Original<FN>(Index)(ecx, edx, sequence_number, input_sample_frametime, active);
-}
-
 void __fastcall BaseClient::FrameStageNotify::Detour(void* ecx, void* edx, ClientFrameStage_t curStage)
 {
 	Table.Original<FN>(Index)(ecx, edx, curStage);
@@ -62,7 +57,6 @@ void BaseClient::Initialize()
 	XASSERT(Table.Hook(&LevelInitPreEntity::Detour, LevelInitPreEntity::Index) == FAILED_TO_HOOK);
 	XASSERT(Table.Hook(&LevelInitPostEntity::Detour, LevelInitPostEntity::Index) == FAILED_TO_HOOK);
 	XASSERT(Table.Hook(&LevelShutdown::Detour, LevelShutdown::Index) == FAILED_TO_HOOK);
-	XASSERT(Table.Hook(&CreateMove::Detour, CreateMove::Index) == FAILED_TO_HOOK);
 	XASSERT(Table.Hook(&FrameStageNotify::Detour, FrameStageNotify::Index) == FAILED_TO_HOOK);
 	XASSERT(Table.Hook(&DispatchUserMessage::Detour, DispatchUserMessage::Index) == FAILED_TO_HOOK);
 }

--- a/Hooks/Client/Client.h
+++ b/Hooks/Client/Client.h
@@ -38,14 +38,6 @@ namespace Hooks
 			void __fastcall Detour(void* ecx, void* edx);
 		}
 
-		namespace CreateMove
-		{
-			using FN = void(__fastcall*)(void*, void*, int, float, bool);
-			constexpr uint32 Index = 21u;
-
-			void __fastcall Detour(void* ecx, void* edx, int sequence_number, float input_sample_frametime, bool active);
-		}
-
 		namespace FrameStageNotify
 		{
 			using FN = void(__fastcall*)(void*, void*, ClientFrameStage_t);


### PR DESCRIPTION
Just removes BaseClient::CreateMove hook as it causes problems with certain features people may one to create.